### PR TITLE
0.0.8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,9 +60,9 @@ credentials that will be used to query for instances. Replace
 The following configuration options are supported:
 
 -  **aws\_access\_key\_id** (Optional str): The AWS IAM access key for a
-   specific user.
+   specific user. Allow 'None' to let boto3 handles credentials
 -  **aws\_secret\_access\_key** (Optional str): The AWS IAM secret key
-   for a specific user.
+   for a specific user. Allow 'None' to let boto3 handles credentials
 -  **aws\_role\_arn** (Optional str): The AWS IAM role to assume to authenticate
    with if you wish to use IAM roles to authenticate across accounts. See `AWS Documentation`_ for more information.
 -  **region** (Optional str): The AWS region to query for the account.

--- a/src/check_reserved_instances/aws.py
+++ b/src/check_reserved_instances/aws.py
@@ -31,6 +31,11 @@ def create_boto_session(account):
     aws_role_arn = account['aws_role_arn']
     region = account['region']
 
+    if aws_access_key_id == "None":
+        aws_access_key_id = None
+    if aws_secret_access_key == "None":
+        aws_secret_access_key = None
+
     if aws_role_arn:
         sts_client = boto3.client('sts', region_name=region)
         creds = sts_client.assume_role(

--- a/src/check_reserved_instances/report.py
+++ b/src/check_reserved_instances/report.py
@@ -11,6 +11,8 @@ import jinja2
 
 import pkg_resources
 
+import datetime
+
 from check_reserved_instances.aws import instance_ids, reserve_expiry
 
 TEMPLATE_DIR = pkg_resources.resource_filename(
@@ -75,7 +77,7 @@ def report_results(config, results):
 
         print('\nSending emails to {}'.format(smtp_recipients))
         mailmsg = MIMEMultipart('alternative')
-        mailmsg['Subject'] = 'Reserved Instance Report' + config['Accounts'][0]['name']
+        mailmsg['Subject'] = 'Reserved Instance Report [' + config['Accounts'][0]['name'] + ']  - ' + str(datetime.datetime.now().strftime("%Y-%m-%d %H:%M"))
         mailmsg['To'] = smtp_recipients
         mailmsg['From'] = smtp_sendas
         email_text = MIMEText(report_text, 'plain')

--- a/src/check_reserved_instances/report.py
+++ b/src/check_reserved_instances/report.py
@@ -75,7 +75,7 @@ def report_results(config, results):
 
         print('\nSending emails to {}'.format(smtp_recipients))
         mailmsg = MIMEMultipart('alternative')
-        mailmsg['Subject'] = 'Reserved Instance Report'
+        mailmsg['Subject'] = 'Reserved Instance Report' + config['Accounts'][0]['name']
         mailmsg['To'] = smtp_recipients
         mailmsg['From'] = smtp_sendas
         email_text = MIMEText(report_text, 'plain')

--- a/src/check_reserved_instances/report.py
+++ b/src/check_reserved_instances/report.py
@@ -88,7 +88,7 @@ def report_results(config, results):
             smtp.starttls()
         if smtp_user:
             smtp.login(smtp_user, smtp_password)
-        smtp.sendmail(smtp_sendas, smtp_recipients, mailmsg)
+        smtp.sendmail(smtp_sendas, smtp_recipients.split(','), mailmsg)
         smtp.quit()
     else:
         print('\nNot sending email for this report')


### PR DESCRIPTION
fixed ability to send to multiple email recipients
allow 'None' as aws_access_key_id and aws_secret_access_key, to make use of boto3 credentials
added project names and datetime to email subject